### PR TITLE
PEP8 refactoring according to pylint warnings

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,66 +1,101 @@
-#!/usr/local/bin/python3/
-import bmstu_schedule
-from config import access_token, path_to_vault
-from datetime import datetime
-from logger.logger import logger
-import os.path
+'''
+Bot main module
+'''
 import re
+import os.path
+from datetime import datetime
+import urllib3
+
+import bmstu_schedule
 import telebot
+from config import TOKEN, VAULT_PATH, GROUP_CODE_REGEX
+from logger.logger import logger
 
-bot = telebot.TeleBot(access_token)
-reg = re.compile('^[а-яА-Я]{1,4}\d{0,2}\-\d{0,3}[а-яА-Я]?$')
-dt = datetime.strptime('2018-09-03', '%Y-%m-%d')
-schedule_file = '{}/Расписание {}.ics'
+BOT = telebot.TeleBot(TOKEN)
+GC_REG_MATCHER = re.compile(GROUP_CODE_REGEX)
+DT = datetime.strptime('2018-09-03', '%Y-%m-%d')
+SCHEDULE_FILE = '{}/Расписание {}.ics'
 
-@bot.message_handler(commands=['start'])
+
+@BOT.message_handler(commands=['start'])
 def start(message):
+    '''
+    handler for user /start command
+    '''
     logger(message)
-    bot.send_message(message.chat.id, text='Привет!\nЯ помогу тебе получить твоё расписание в формате,\nудобном для встраивания в любые календари,\nнапример, Google Calendar или macOS Calendar, и еще \nкучу других.\nВ какой группе учишься?')
+    BOT.send_message(message.chat.id, text=(
+        'Привет!\nЯ помогу тебе получить твоё расписание '
+        'в формате,\nудобном для встраивания в любые календари,'
+        '\nнапример, Google Calendar или macOS Calendar, и еще '
+        '\nкучу других.\nВ какой группе учишься?'))
 
-def group_validator(group_id):
-    return reg.match(group_id) != None
 
 def file_exist(file_name):
-    return os.path.isfile(schedule_file.format(path_to_vault,file_name))
+    '''
+    file existing
+    checker
+    '''
+    return os.path.isfile(SCHEDULE_FILE.format(VAULT_PATH, file_name))
 
-@bot.message_handler(content_types=['text'])
+
+@BOT.message_handler(content_types=['text'])
 def any_messages(message):
+    '''
+    handler for any
+    message containing text
+    '''
     logger(message)
     file_to_send = ''
 
-    if group_validator(message.text):
-        message.text = message.text.upper()
-        bot.send_message(message.chat.id, text='Пошел искать расписание для группы {}'.format(message.text))
+    if not GC_REG_MATCHER.match(message.text):
+        BOT.send_message(
+            message.chat.id, text='Указан неверный формат номера группы.')
+        return
+    message.text = message.text.upper()
+    BOT.send_message(
+        message.chat.id,
+        text='Пошел искать расписание для группы {}'.format(message.text))
+
+    if file_exist(message.text):
+        file_to_send = open(SCHEDULE_FILE.format(
+            ValueError, message.text), 'rb')
+    else:
+        try:
+            bmstu_schedule.run(message.text, DT, VAULT_PATH)
+        except SystemExit:
+            BOT.send_message(
+                message.chat.id, text=(
+                    'Чёт я ничего не нашел для группы {}. '
+                    'Если проблема и правда во мне, то напиши '
+                    '@lee_daniil или @gabolaev'.format(message.text)))
+            return
 
         if file_exist(message.text):
-            file_to_send = open(schedule_file.format(path_to_vault, message.text), 'rb')
-        else:
-            try:
-                bmstu_schedule.run(message.text, dt, path_to_vault)
-            except SystemExit as ex:
-                bot.send_message(message.chat.id, text='Чёт я ничего не нашел для группы {}. Если проблема и правда во мне, то напиши @lee_daniil или @gabolaev'.format(message.text))
-                return
+            file_to_send = open(SCHEDULE_FILE.format(
+                VAULT_PATH, message.text), 'rb')
+        elif message.text[len(message.text)-1].isnumeric():
+            BOT.send_message(
+                message.chat.id, text=(
+                    'Эээ, кажется, кто-то не уточнил тип своей '
+                    'группы (Б/М/А). Давай добавим соответствующую  '
+                    'букву в конце и попробуем еще раз.  '
+                    'Например {}Б'.format(message.text)))
+            return
 
-            if file_exist(message.text):
-                file_to_send = open(schedule_file.format(path_to_vault, message.text), 'rb')
-            elif message.text[len(message.text)-1].isnumeric():
-                    bot.send_message(message.chat.id, text="Эээ, кажется, кто-то не уточнил тип своей группы (Б/М/А). Давай добавим соответствующую букву в конце и попробуем еще раз. Например {}Б".format(message.text))
-                    return
-    else:
-        bot.send_message(message.chat.id, text='Указан неверный формат номера группы.')
-        return
-        
     if file_to_send:
-        bot.send_document(message.chat.id, file_to_send)
-        bot.send_message(message.chat.id, text='Тадам!')
-        bot.send_message(message.chat.id, text='Если вдруг будут проблемы при импорте в календарь, можешь обращаться к @lee_daniil или @gabolaev')
+        BOT.send_document(message.chat.id, file_to_send)
+        BOT.send_message(message.chat.id, text='Тадам!')
+        BOT.send_message(
+            message.chat.id, text=(
+                'Если вдруг будут проблемы при импорте в '
+                'календарь, можешь обращаться к @lee_daniil или @gabolaev'))
     else:
-        bot.send_message(message.chat.id, text='Указан неверный формат номера группы.')
+        BOT.send_message(
+            message.chat.id, text='Указан неверный формат номера группы.')
 
-    
+
 if __name__ == '__main__':
     try:
-        bot.polling(none_stop=True, timeout=30)
-    except Exception as ex:
+        BOT.polling(none_stop=True, timeout=30)
+    except urllib3.exceptions.ReadTimeoutError:
         pass
-        

--- a/config.py
+++ b/config.py
@@ -1,2 +1,8 @@
-filesaccess_token = 'TELEGRAM BOT TOKEN'
-path_to_vault = 'ABSOLUTE PATH TO VAULT FOLDER' # vault - folder with downloaded .ics
+'''
+Configuration file
+'''
+
+TOKEN = 'TELEGRAM BOT TOKEN'
+# vault - folder with downloaded .ics
+VAULT_PATH = 'ABSOLUTE PATH TO VAULT FOLDER'
+GROUP_CODE_REGEX = '^[а-яА-Я]{1,4}\d{0,2}\-\d{0,3}[а-яА-Я]?$'

--- a/config.py
+++ b/config.py
@@ -5,4 +5,4 @@ Configuration file
 TOKEN = 'TELEGRAM BOT TOKEN'
 # vault - folder with downloaded .ics
 VAULT_PATH = 'ABSOLUTE PATH TO VAULT FOLDER'
-GROUP_CODE_REGEX = '^[а-яА-Я]{1,4}\d{0,2}\-\d{0,3}[а-яА-Я]?$'
+GROUP_CODE_REGEX = r'^[а-яА-Я]{1,4}\d{0,2}\-\d{0,3}[а-яА-Я]?$'


### PR DESCRIPTION
Before refactoring:
``` bash
❯ pylint *.py
************* Module bot
bot.py:18:0: C0301: Line too long (241/100) (line-too-long)
bot.py:24:60: C0326: Exactly one space required after comma
    return os.path.isfile(schedule_file.format(path_to_vault,file_name))
                                                            ^ (bad-whitespace)
bot.py:33:0: C0301: Line too long (108/100) (line-too-long)
bot.py:41:0: C0301: Line too long (182/100) (line-too-long)
bot.py:47:0: C0301: Line too long (218/100) (line-too-long)
bot.py:47:0: W0311: Bad indentation. Found 20 spaces, expected 16 (bad-indentation)
bot.py:48:0: W0311: Bad indentation. Found 20 spaces, expected 16 (bad-indentation)
bot.py:52:0: C0303: Trailing whitespace (trailing-whitespace)
bot.py:56:0: C0301: Line too long (146/100) (line-too-long)
bot.py:60:0: C0303: Trailing whitespace (trailing-whitespace)
bot.py:11:0: W1401: Anomalous backslash in string: '\d'. String constant might be missing an r prefix. (anomalous-backslash-in-string)
bot.py:11:0: W1401: Anomalous backslash in string: '\-'. String constant might be missing an r prefix. (anomalous-backslash-in-string)
bot.py:11:0: W1401: Anomalous backslash in string: '\d'. String constant might be missing an r prefix. (anomalous-backslash-in-string)
bot.py:1:0: C0111: Missing module docstring (missing-docstring)
bot.py:3:0: E0611: No name 'access_token' in module 'config' (no-name-in-module)
bot.py:10:0: C0103: Constant name "bot" doesn't conform to UPPER_CASE naming style (invalid-name)
bot.py:11:0: C0103: Constant name "reg" doesn't conform to UPPER_CASE naming style (invalid-name)
bot.py:12:0: C0103: Constant name "dt" doesn't conform to UPPER_CASE naming style (invalid-name)
bot.py:13:0: C0103: Constant name "schedule_file" doesn't conform to UPPER_CASE naming style (invalid-name)
bot.py:16:0: C0111: Missing function docstring (missing-docstring)
bot.py:20:0: C0111: Missing function docstring (missing-docstring)
bot.py:21:11: C0121: Comparison to None should be 'expr is not None' (singleton-comparison)
bot.py:23:0: C0111: Missing function docstring (missing-docstring)
bot.py:27:0: C0111: Missing function docstring (missing-docstring)
bot.py:40:12: W0612: Unused variable 'ex' (unused-variable)
bot.py:64:11: W0703: Catching too general exception Exception (broad-except)
bot.py:4:0: C0411: standard import "from datetime import datetime" should be placed before "import bmstu_schedule" (wrong-import-order)
bot.py:6:0: C0411: standard import "import os.path" should be placed before "import bmstu_schedule" (wrong-import-order)
bot.py:7:0: C0411: standard import "import re" should be placed before "import bmstu_schedule" (wrong-import-order)
bot.py:8:0: C0411: third party import "import telebot" should be placed before "from config import access_token, path_to_vault" (wrong-import-order)
************* Module config
config.py:2:0: C0304: Final newline missing (missing-final-newline)
config.py:1:0: C0111: Missing module docstring (missing-docstring)
config.py:1:0: C0103: Constant name "filesaccess_token" doesn't conform to UPPER_CASE naming style (invalid-name)
config.py:2:0: C0103: Constant name "path_to_vault" doesn't conform to UPPER_CASE naming style (invalid-name)

-------------------------------------------------------------------
Your code has been rated at 2.40/10
```

After: 
``` bash
❯ pylint *.py

-------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 2.40/10, +7.60)
```